### PR TITLE
feat: reforça automações de reservas e consultas

### DIFF
--- a/Automation/Dtos/AssistantDecision.cs
+++ b/Automation/Dtos/AssistantDecision.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace Automation.Dtos;
+
+public class AssistantDecision
+{
+    public string? Acao { get; set; }
+    public string? CodigoReserva { get; set; }
+    public Guid? IdConversa { get; set; }
+    public Guid? IdCliente { get; set; }
+    public Guid? IdEstabelecimento { get; set; }
+    public string? NomeCliente { get; set; }
+    public int? QuantidadePessoas { get; set; }
+    public DateTime? Data { get; set; }
+    public TimeSpan? Hora { get; set; }
+    public IDictionary<string, string>? MemoriaHidratada { get; set; }
+    public IDictionary<string, object?>? ContextoAdicional { get; set; }
+
+    public bool EhAcao(string acao) => string.Equals(Acao, acao, StringComparison.OrdinalIgnoreCase);
+
+    public static class Acoes
+    {
+        public const string ConfirmarReserva = "confirmar_reserva";
+        public const string ConsultarReserva = "consultar_reserva";
+        public const string AtualizarReserva = "atualizar_reserva";
+        public const string CancelarReserva = "cancelar_reserva";
+    }
+}

--- a/Automation/Dtos/HandoverContextDto.cs
+++ b/Automation/Dtos/HandoverContextDto.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Automation.Dtos;
+
+public class HandoverContextDto
+{
+    public string? AcaoSolicitada { get; set; }
+    public TentativaReservaSnapshotDto? TentativaReservaSnapshot { get; set; }
+    public string? CodigoReserva { get; set; }
+    public string? ResumoConflito { get; set; }
+    public string? Observacoes { get; set; }
+}
+
+public class TentativaReservaSnapshotDto
+{
+    public string? NomeCliente { get; set; }
+    public int? QuantidadePessoas { get; set; }
+    public DateTime? Data { get; set; }
+    public TimeSpan? Hora { get; set; }
+}

--- a/Automation/Infra/Config/Program.cs
+++ b/Automation/Infra/Config/Program.cs
@@ -1,0 +1,122 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Automation.Dtos;
+using Automation.Interfaces;
+using Automation.Repository;
+using Automation.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.Extensions.Http;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddLogging();
+builder.Services.AddMemoryCache();
+
+builder.Services.AddHttpClient("OpenAI", (sp, client) =>
+{
+    var configuration = sp.GetRequiredService<IConfiguration>();
+    var baseUrl = configuration["OpenAI:BaseUrl"] ?? "https://api.openai.com/";
+    var timeoutSeconds = configuration.GetValue("OpenAI:TimeoutSeconds", 45);
+    client.BaseAddress = new Uri(baseUrl);
+    client.Timeout = TimeSpan.FromSeconds(timeoutSeconds);
+}).AddPolicyHandler(PollyPolicies.ObterRetryPolicy());
+
+builder.Services.AddSingleton<IConversationRepository, ConversationRepository>();
+builder.Services.AddSingleton<IReservaRepository, ReservaRepository>();
+builder.Services.AddSingleton<ConversationContextService>();
+builder.Services.AddSingleton<ReservaService>();
+builder.Services.AddSingleton<ToolExecutorService>();
+builder.Services.AddSingleton<HandoverService>();
+builder.Services.AddSingleton<IAssistantService, AssistantService>();
+
+var app = builder.Build();
+
+app.UseMiddleware<IdempotencyMiddleware>();
+
+app.MapPost("/wa/webhook", async (IAssistantService assistantService, AssistantDecision decisao, CancellationToken cancellationToken) =>
+{
+    await assistantService.ProcessarMensagemAsync(decisao, cancellationToken);
+    return Results.Ok();
+});
+
+app.Run();
+
+public static class PollyPolicies
+{
+    public static IAsyncPolicy<HttpResponseMessage> ObterRetryPolicy()
+    {
+        return HttpPolicyExtensions
+            .HandleTransientHttpError()
+            .Or<TaskCanceledException>()
+            .WaitAndRetryAsync(2, tentativa => TimeSpan.FromSeconds(Math.Pow(2, tentativa)));
+    }
+}
+
+public class IdempotencyMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly IMemoryCache _memoryCache;
+    private readonly ILogger<IdempotencyMiddleware> _logger;
+
+    public IdempotencyMiddleware(RequestDelegate next, IMemoryCache memoryCache, ILogger<IdempotencyMiddleware> logger)
+    {
+        _next = next;
+        _memoryCache = memoryCache;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (context.Request.Path.StartsWithSegments("/wa/webhook", StringComparison.OrdinalIgnoreCase))
+        {
+            context.Request.EnableBuffering();
+            using var reader = new StreamReader(context.Request.Body, Encoding.UTF8, leaveOpen: true);
+            var body = await reader.ReadToEndAsync();
+            context.Request.Body.Position = 0;
+
+            try
+            {
+                using var document = JsonDocument.Parse(body);
+                var root = document.RootElement;
+                if (root.TryGetProperty("idConversa", out var idConversaProp) && Guid.TryParse(idConversaProp.GetString(), out var idConversa))
+                {
+                    var texto = root.TryGetProperty("texto", out var textoProp) ? textoProp.GetString() ?? string.Empty : string.Empty;
+                    var chave = GerarChave(idConversa, texto);
+                    if (_memoryCache.TryGetValue(chave, out _))
+                    {
+                        _logger.LogInformation("INF-IDEMPOTENCIA-WEBHOOK-IGNORADA {@Chave}", chave);
+                        context.Response.StatusCode = StatusCodes.Status202Accepted;
+                        await context.Response.WriteAsync("Mensagem já processada recentemente.");
+                        return;
+                    }
+
+                    _memoryCache.Set(chave, true, TimeSpan.FromMinutes(2));
+                    _logger.LogInformation("INF-IDEMPOTENCIA-WEBHOOK-REGISTRADA {@Chave}", chave);
+                }
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogWarning(ex, "WRN-IDEMPOTENCIA-WEBHOOK-JSON-INVALIDO");
+            }
+        }
+
+        await _next(context);
+    }
+
+    private static string GerarChave(Guid idConversa, string texto)
+    {
+        var ticksTruncados = DateTime.UtcNow.Ticks / TimeSpan.FromMinutes(1).Ticks;
+        var hash = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(texto ?? string.Empty)));
+        return $"webhook:{idConversa}:{hash}:{ticksTruncados}";
+    }
+}

--- a/Automation/Interfaces/IAssistantService.cs
+++ b/Automation/Interfaces/IAssistantService.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Automation.Dtos;
+
+namespace Automation.Interfaces;
+
+public interface IAssistantService
+{
+    Task ProcessarMensagemAsync(AssistantDecision decisao, CancellationToken cancellationToken = default);
+}

--- a/Automation/Interfaces/IConversationRepository.cs
+++ b/Automation/Interfaces/IConversationRepository.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Automation.Interfaces;
+
+public interface IConversationRepository
+{
+    Task SalvarContextoAsync(Guid idConversa, string chave, string json, TimeSpan? ttl = null, CancellationToken cancellationToken = default);
+    Task<string?> LerContextoAsync(Guid idConversa, string chave, CancellationToken cancellationToken = default);
+    Task RemoverContextoAsync(Guid idConversa, string chave, CancellationToken cancellationToken = default);
+}

--- a/Automation/Interfaces/IReservaRepository.cs
+++ b/Automation/Interfaces/IReservaRepository.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Automation.Models;
+
+namespace Automation.Interfaces;
+
+public interface IReservaRepository
+{
+    Task<Reserva?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<Reserva?> ObterPorCodigoAsync(string codigo, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<Reserva>> ObterAtivasDoClienteAsync(Guid idCliente, Guid idEstabelecimento, DateTime hoje, CancellationToken cancellationToken = default);
+    Task<bool> ExisteReservaMesmoDiaAsync(Guid idCliente, Guid idEstabelecimento, DateTime dia, CancellationToken cancellationToken = default);
+    Task<bool> VerificarCapacidadeAsync(Guid idEstabelecimento, DateTime dia, TimeSpan hora, int quantidade, CancellationToken cancellationToken = default);
+    Task AtualizarReservaAsync(Guid id, TimeSpan hora, int qtdPessoas, CancellationToken cancellationToken = default);
+    Task SalvarAsync(Reserva reserva, CancellationToken cancellationToken = default);
+    Task CancelarAsync(Guid id, CancellationToken cancellationToken = default);
+}

--- a/Automation/Models/Reserva.cs
+++ b/Automation/Models/Reserva.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Automation.Models;
+
+public class Reserva
+{
+    public Guid Id { get; set; }
+    public Guid IdCliente { get; set; }
+    public Guid IdEstabelecimento { get; set; }
+    public DateTime Data { get; set; }
+    public TimeSpan Hora { get; set; }
+    public int QuantidadePessoas { get; set; }
+    public bool Ativa { get; set; }
+    public DateTime CriadoEm { get; set; }
+    public string CodigoExibicao { get; set; } = string.Empty;
+
+    public string CodigoFormatado => string.IsNullOrWhiteSpace(CodigoExibicao)
+        ? $"#{Id.ToString()[..6].ToUpperInvariant()}"
+        : CodigoExibicao.StartsWith('#') ? CodigoExibicao : $"#{CodigoExibicao}";
+}

--- a/Automation/Repository/ConversationRepository.cs
+++ b/Automation/Repository/ConversationRepository.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Automation.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace Automation.Repository;
+
+public class ConversationRepository : IConversationRepository
+{
+    private readonly ConcurrentDictionary<(Guid, string), (string Json, DateTime? Expira)> _contextos = new();
+    private readonly ILogger<ConversationRepository> _logger;
+
+    public ConversationRepository(ILogger<ConversationRepository> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task SalvarContextoAsync(Guid idConversa, string chave, string json, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+    {
+        var expira = ttl.HasValue ? DateTime.UtcNow.Add(ttl.Value) : null;
+        _contextos[(idConversa, chave)] = (json, expira);
+        _logger.LogInformation("INF-CONVERSATION-REPO-SALVAR {@Conversa} {@Chave}", idConversa, chave);
+        return Task.CompletedTask;
+    }
+
+    public Task<string?> LerContextoAsync(Guid idConversa, string chave, CancellationToken cancellationToken = default)
+    {
+        if (_contextos.TryGetValue((idConversa, chave), out var registro))
+        {
+            if (registro.Expira.HasValue && registro.Expira.Value < DateTime.UtcNow)
+            {
+                _contextos.TryRemove((idConversa, chave), out _);
+                return Task.FromResult<string?>(null);
+            }
+
+            return Task.FromResult<string?>(registro.Json);
+        }
+
+        return Task.FromResult<string?>(null);
+    }
+
+    public Task RemoverContextoAsync(Guid idConversa, string chave, CancellationToken cancellationToken = default)
+    {
+        _contextos.TryRemove((idConversa, chave), out _);
+        _logger.LogInformation("INF-CONVERSATION-REPO-REMOVER {@Conversa} {@Chave}", idConversa, chave);
+        return Task.CompletedTask;
+    }
+}

--- a/Automation/Repository/ReservaRepository.cs
+++ b/Automation/Repository/ReservaRepository.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Automation.Interfaces;
+using Automation.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Automation.Repository;
+
+public class ReservaRepository : IReservaRepository
+{
+    private readonly ConcurrentDictionary<Guid, Reserva> _reservas = new();
+    private readonly ILogger<ReservaRepository> _logger;
+
+    public ReservaRepository(ILogger<ReservaRepository> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task<Reserva?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        _reservas.TryGetValue(id, out var reserva);
+        return Task.FromResult(reserva);
+    }
+
+    public Task<Reserva?> ObterPorCodigoAsync(string codigo, CancellationToken cancellationToken = default)
+    {
+        var normalizado = codigo.StartsWith('#') ? codigo[1..] : codigo;
+        var reserva = _reservas.Values.FirstOrDefault(r => string.Equals(r.CodigoExibicao, normalizado, StringComparison.OrdinalIgnoreCase) || string.Equals(r.CodigoFormatado.TrimStart('#'), normalizado, StringComparison.OrdinalIgnoreCase));
+        return Task.FromResult(reserva);
+    }
+
+    public Task<IReadOnlyList<Reserva>> ObterAtivasDoClienteAsync(Guid idCliente, Guid idEstabelecimento, DateTime hoje, CancellationToken cancellationToken = default)
+    {
+        var lista = _reservas.Values
+            .Where(r => r.IdCliente == idCliente && r.IdEstabelecimento == idEstabelecimento && r.Ativa && r.Data.Date >= hoje.Date)
+            .OrderBy(r => r.Data)
+            .ThenBy(r => r.Hora)
+            .ToList();
+        return Task.FromResult<IReadOnlyList<Reserva>>(lista);
+    }
+
+    public Task<bool> ExisteReservaMesmoDiaAsync(Guid idCliente, Guid idEstabelecimento, DateTime dia, CancellationToken cancellationToken = default)
+    {
+        var existe = _reservas.Values.Any(r => r.IdCliente == idCliente && r.IdEstabelecimento == idEstabelecimento && r.Ativa && r.Data.Date == dia.Date);
+        return Task.FromResult(existe);
+    }
+
+    public Task<bool> VerificarCapacidadeAsync(Guid idEstabelecimento, DateTime dia, TimeSpan hora, int quantidade, CancellationToken cancellationToken = default)
+    {
+        // Regra simplificada: capacidade máxima por horário = 50 pessoas.
+        const int capacidadeMaxima = 50;
+        var ocupacao = _reservas.Values
+            .Where(r => r.IdEstabelecimento == idEstabelecimento && r.Data.Date == dia.Date && r.Hora == hora && r.Ativa)
+            .Sum(r => r.QuantidadePessoas);
+        var disponivel = ocupacao + quantidade <= capacidadeMaxima;
+        _logger.LogInformation("INF-RESERVA-VERIFICAR-CAPACIDADE {@Estabelecimento} {@Data} {@Hora} {@Quantidade} {@Disponivel}", idEstabelecimento, dia, hora, quantidade, disponivel);
+        return Task.FromResult(disponivel);
+    }
+
+    public Task AtualizarReservaAsync(Guid id, TimeSpan hora, int qtdPessoas, CancellationToken cancellationToken = default)
+    {
+        _reservas.AddOrUpdate(id, _ => throw new InvalidOperationException("Reserva não encontrada"), (_, reserva) =>
+        {
+            reserva.Hora = hora;
+            reserva.QuantidadePessoas = qtdPessoas;
+            return reserva;
+        });
+        _logger.LogInformation("INF-RESERVA-REPO-ATUALIZAR {@Reserva}", id);
+        return Task.CompletedTask;
+    }
+
+    public Task SalvarAsync(Reserva reserva, CancellationToken cancellationToken = default)
+    {
+        reserva.CriadoEm = DateTime.UtcNow;
+        _reservas[reserva.Id] = reserva;
+        _logger.LogInformation("INF-RESERVA-REPO-SALVAR {@Reserva}", reserva.Id);
+        return Task.CompletedTask;
+    }
+
+    public Task CancelarAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        if (_reservas.TryGetValue(id, out var reserva))
+        {
+            reserva.Ativa = false;
+            _logger.LogInformation("INF-RESERVA-REPO-CANCELAR {@Reserva}", id);
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/Automation/Services/AssistantService.cs
+++ b/Automation/Services/AssistantService.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Automation.Dtos;
+using Automation.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace Automation.Services;
+
+public class AssistantService : IAssistantService
+{
+    private readonly ToolExecutorService _toolExecutorService;
+    private readonly ConversationContextService _conversationContextService;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IMemoryCache _memoryCache;
+    private readonly ILogger<AssistantService> _logger;
+
+    public AssistantService(
+        ToolExecutorService toolExecutorService,
+        ConversationContextService conversationContextService,
+        IHttpClientFactory httpClientFactory,
+        IMemoryCache memoryCache,
+        ILogger<AssistantService> logger)
+    {
+        _toolExecutorService = toolExecutorService;
+        _conversationContextService = conversationContextService;
+        _httpClientFactory = httpClientFactory;
+        _memoryCache = memoryCache;
+        _logger = logger;
+    }
+
+    public async Task ProcessarMensagemAsync(AssistantDecision decisao, CancellationToken cancellationToken = default)
+    {
+        if (decisao is null)
+        {
+            throw new ArgumentNullException(nameof(decisao));
+        }
+
+        if (!RegistrarIdempotencia(decisao))
+        {
+            _logger.LogInformation("INF-ASSISTANT-IDEMPOTENTE {@Conversa}", decisao.IdConversa);
+            return;
+        }
+
+        await HidratarMemoriaAsync(decisao, cancellationToken);
+
+        ToolExecutionResult resultado;
+        if (decisao.EhAcao(AssistantDecision.Acoes.ConsultarReserva))
+        {
+            resultado = await _toolExecutorService.HandleConsultarReservaAsync(decisao, cancellationToken);
+        }
+        else if (decisao.EhAcao(AssistantDecision.Acoes.AtualizarReserva))
+        {
+            resultado = await _toolExecutorService.HandleAtualizarReservaAsync(decisao, cancellationToken);
+        }
+        else if (decisao.EhAcao(AssistantDecision.Acoes.ConfirmarReserva))
+        {
+            resultado = await _toolExecutorService.HandleConfirmarReservaAsync(decisao, cancellationToken);
+        }
+        else
+        {
+            _logger.LogWarning("WRN-ASSISTANT-ACAO-DESCONHECIDA {@Acao}", decisao.Acao);
+            resultado = ToolExecutionResult.Falha("Ainda não sei lidar com esse pedido. Pode tentar reformular?");
+        }
+
+        _logger.LogInformation("INF-ASSISTANT-RESULTADO {@Acao} {@Sucesso} {@Mensagem}", decisao.Acao, resultado.Success, resultado.Message);
+    }
+
+    private bool RegistrarIdempotencia(AssistantDecision decisao)
+    {
+        if (decisao.IdConversa is null)
+        {
+            return true;
+        }
+
+        var texto = decisao.ContextoAdicional != null && decisao.ContextoAdicional.TryGetValue("texto_usuario", out var valorTexto)
+            ? valorTexto?.ToString() ?? string.Empty
+            : string.Empty;
+
+        var ticksTruncados = DateTime.UtcNow.Ticks / TimeSpan.FromMinutes(1).Ticks;
+        var hashEntrada = CalcularHash($"{decisao.IdConversa}:{texto}");
+        var chave = $"idemp:{decisao.IdConversa}:{hashEntrada}:{ticksTruncados}";
+
+        if (_memoryCache.TryGetValue(chave, out _))
+        {
+            _logger.LogInformation("INF-ASSISTANT-IDEMPOTENCIA-IGNORADA {@Chave}", chave);
+            return false;
+        }
+
+        _memoryCache.Set(chave, true, TimeSpan.FromMinutes(2));
+        _logger.LogInformation("INF-ASSISTANT-IDEMPOTENCIA-REGISTRADA {@Chave}", chave);
+        return true;
+    }
+
+    private async Task HidratarMemoriaAsync(AssistantDecision decisao, CancellationToken cancellationToken)
+    {
+        if (decisao.IdConversa is null)
+        {
+            return;
+        }
+
+        var snapshot = await _conversationContextService.LerAsync<TentativaReservaSnapshotDto>(decisao.IdConversa.Value, "tentativa_reserva", cancellationToken);
+        if (snapshot is null)
+        {
+            return;
+        }
+
+        bool alterado = false;
+        if (string.IsNullOrWhiteSpace(decisao.NomeCliente) && !string.IsNullOrWhiteSpace(snapshot.NomeCliente))
+        {
+            decisao.NomeCliente = snapshot.NomeCliente;
+            alterado = true;
+        }
+
+        if (decisao.QuantidadePessoas is null && snapshot.QuantidadePessoas.HasValue)
+        {
+            decisao.QuantidadePessoas = snapshot.QuantidadePessoas;
+            alterado = true;
+        }
+
+        if (decisao.Data is null && snapshot.Data.HasValue)
+        {
+            decisao.Data = snapshot.Data;
+            alterado = true;
+        }
+
+        if (decisao.Hora is null && snapshot.Hora.HasValue)
+        {
+            decisao.Hora = snapshot.Hora;
+            alterado = true;
+        }
+
+        if (alterado)
+        {
+            _logger.LogInformation("INF-ASSISTANT-MEMORIA-HIDRATADA {@Conversa} {@Snapshot}", decisao.IdConversa, JsonSerializer.Serialize(snapshot));
+        }
+    }
+
+    private async Task<string> EnviarParaOpenAIAsync(string payload, CancellationToken cancellationToken)
+    {
+        var client = _httpClientFactory.CreateClient("OpenAI");
+        using var request = new HttpRequestMessage(HttpMethod.Post, "v1/chat/completions")
+        {
+            Content = new StringContent(payload, Encoding.UTF8, "application/json")
+        };
+
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            var response = await client.SendAsync(request, cancellationToken);
+            stopwatch.Stop();
+            _logger.LogInformation("INF-ASSISTANT-OPENAI-LATENCIA {LatenciaMs}", stopwatch.ElapsedMilliseconds);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync(cancellationToken);
+        }
+        catch (TaskCanceledException ex)
+        {
+            stopwatch.Stop();
+            _logger.LogWarning(ex, "WRN-ASSISTANT-OPENAI-TIMEOUT {LatenciaMs}", stopwatch.ElapsedMilliseconds);
+            return "Desculpe, a resposta está demorando um pouco. Vamos continuar com as informações que já temos.";
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            _logger.LogError(ex, "ERR-ASSISTANT-OPENAI-FALHA {LatenciaMs}", stopwatch.ElapsedMilliseconds);
+            throw;
+        }
+    }
+
+    private static string CalcularHash(string texto)
+    {
+        var bytes = Encoding.UTF8.GetBytes(texto);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexString(hash);
+    }
+}

--- a/Automation/Services/ConversationContextService.cs
+++ b/Automation/Services/ConversationContextService.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Automation.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace Automation.Services;
+
+public class ConversationContextService
+{
+    private readonly IConversationRepository _repository;
+    private readonly ILogger<ConversationContextService> _logger;
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+
+    public ConversationContextService(IConversationRepository repository, ILogger<ConversationContextService> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task SalvarAsync<T>(Guid idConversa, string chave, T payload, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+    {
+        var json = JsonSerializer.Serialize(payload, SerializerOptions);
+        _logger.LogInformation("INF-CONVERSATION-CONTEXT-SAVE {@Chave} {@Id}", chave, idConversa);
+        await _repository.SalvarContextoAsync(idConversa, chave, json, ttl, cancellationToken);
+    }
+
+    public async Task<T?> LerAsync<T>(Guid idConversa, string chave, CancellationToken cancellationToken = default)
+    {
+        var json = await _repository.LerContextoAsync(idConversa, chave, cancellationToken);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return default;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<T>(json, SerializerOptions);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "WRN-CONVERSATION-CONTEXT-DESERIALIZE {@Chave} {@Id}", chave, idConversa);
+            return default;
+        }
+    }
+
+    public Task RemoverAsync(Guid idConversa, string chave, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("INF-CONVERSATION-CONTEXT-REMOVE {@Chave} {@Id}", chave, idConversa);
+        return _repository.RemoverContextoAsync(idConversa, chave, cancellationToken);
+    }
+}

--- a/Automation/Services/HandoverService.cs
+++ b/Automation/Services/HandoverService.cs
@@ -1,0 +1,31 @@
+using System;
+using Automation.Dtos;
+using Automation.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Automation.Services;
+
+public class HandoverService
+{
+    private readonly ILogger<HandoverService> _logger;
+
+    public HandoverService(ILogger<HandoverService> logger)
+    {
+        _logger = logger;
+    }
+
+    public HandoverContextDto GerarContexto(string acaoSolicitada, Reserva? reservaConflitante, TentativaReservaSnapshotDto? snapshot, string? codigoReserva, string? resumoExtra)
+    {
+        var contexto = new HandoverContextDto
+        {
+            AcaoSolicitada = acaoSolicitada,
+            TentativaReservaSnapshot = snapshot,
+            CodigoReserva = codigoReserva,
+            ResumoConflito = reservaConflitante != null ? $"Conflito detectado em {reservaConflitante.Data:dd/MM/yyyy} às {reservaConflitante.Hora:hh\\:mm} para {reservaConflitante.QuantidadePessoas} pessoas." : null,
+            Observacoes = resumoExtra
+        };
+
+        _logger.LogInformation("INF-HANDOVER-CONTEXTO {@Acao} {@Codigo}", acaoSolicitada, codigoReserva);
+        return contexto;
+    }
+}

--- a/Automation/Services/ReservaService.cs
+++ b/Automation/Services/ReservaService.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Automation.Interfaces;
+using Automation.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Automation.Services;
+
+public class ReservaService
+{
+    private readonly IReservaRepository _reservaRepository;
+    private readonly ILogger<ReservaService> _logger;
+
+    public ReservaService(IReservaRepository reservaRepository, ILogger<ReservaService> logger)
+    {
+        _reservaRepository = reservaRepository;
+        _logger = logger;
+    }
+
+    public async Task<Reserva?> ObterReservaPorCodigoAsync(string codigo, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(codigo))
+        {
+            return null;
+        }
+
+        var normalizado = codigo.StartsWith('#') ? codigo[1..] : codigo;
+        _logger.LogInformation("INF-RESERVA-BUSCA-CODIGO {@Codigo}", normalizado);
+        return await _reservaRepository.ObterPorCodigoAsync(normalizado, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<Reserva>> ObterReservasAtivasDoClienteAsync(Guid clienteId, Guid estabelecimentoId, DateTime referencia, CancellationToken cancellationToken = default)
+    {
+        var resultado = await _reservaRepository.ObterAtivasDoClienteAsync(clienteId, estabelecimentoId, referencia.Date, cancellationToken);
+        _logger.LogInformation("INF-RESERVA-BUSCA-ATIVAS {@Cliente} {@Estabelecimento} {@Quantidade}", clienteId, estabelecimentoId, resultado.Count);
+        return resultado;
+    }
+
+    public async Task<bool> ExisteConflitoMesmoDiaAsync(Guid clienteId, Guid estabelecimentoId, DateTime data, CancellationToken cancellationToken = default)
+    {
+        var existe = await _reservaRepository.ExisteReservaMesmoDiaAsync(clienteId, estabelecimentoId, data.Date, cancellationToken);
+        _logger.LogInformation("INF-RESERVA-CONFLITO-MESMO-DIA {@Cliente} {@Estabelecimento} {@Data} {@Existe}", clienteId, estabelecimentoId, data.Date, existe);
+        return existe;
+    }
+
+    public async Task<bool> AtualizarReservaComCapacidadeAsync(Guid reservaId, Guid estabelecimentoId, DateTime data, TimeSpan novaHora, int novaQtd, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("INF-RESERVA-ATUALIZAR-REQUEST {@Reserva} {@Hora} {@Qtd}", reservaId, novaHora, novaQtd);
+        var possuiCapacidade = await _reservaRepository.VerificarCapacidadeAsync(estabelecimentoId, data.Date, novaHora, novaQtd, cancellationToken);
+        if (!possuiCapacidade)
+        {
+            _logger.LogWarning("WRN-RESERVA-ATUALIZAR-SEM-CAPACIDADE {@Reserva}", reservaId);
+            return false;
+        }
+
+        await _reservaRepository.AtualizarReservaAsync(reservaId, novaHora, novaQtd, cancellationToken);
+        _logger.LogInformation("INF-RESERVA-ATUALIZADA {@Reserva}", reservaId);
+        return true;
+    }
+
+    public string MontarResumoReserva(Reserva reserva)
+    {
+        return $"📅 Data: {reserva.Data:dd/MM/yyyy}\n⏰ Horário: {reserva.Hora:hh\\:mm}\n👥 Pessoas: {reserva.QuantidadePessoas}";
+    }
+
+    public Reserva? SelecionarReservaMesmoDia(IEnumerable<Reserva> reservas, DateTime data)
+    {
+        return reservas.FirstOrDefault(r => r.Data.Date == data.Date && r.Ativa);
+    }
+}

--- a/Automation/Services/ToolExecutorService.cs
+++ b/Automation/Services/ToolExecutorService.cs
@@ -1,0 +1,284 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Automation.Dtos;
+using Automation.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Automation.Services;
+
+public class ToolExecutorService
+{
+    private static readonly string[] ValoresInvalidos =
+    {
+        "não informada", "nao informada", "não informado", "nao informado", "a definir", "a combinar", "undefined", "null", "string"
+    };
+
+    private const string TentativaReservaContextKey = "tentativa_reserva";
+    private const string DecisaoConflitoContextKey = "decisao_reserva_conflito";
+
+    private readonly ReservaService _reservaService;
+    private readonly ConversationContextService _contextService;
+    private readonly ILogger<ToolExecutorService> _logger;
+
+    public ToolExecutorService(ReservaService reservaService, ConversationContextService contextService, ILogger<ToolExecutorService> logger)
+    {
+        _reservaService = reservaService;
+        _contextService = contextService;
+        _logger = logger;
+    }
+
+    private static readonly JsonElement ConsultarReservaSchema = JsonSerializer.Deserialize<JsonElement>(@"{
+        \"type\": \"object\",
+        \"properties\": {
+            \"idConversa\": { \"type\": \"string\", \"format\": \"uuid\" },
+            \"codigoReserva\": { \"type\": \"string\" }
+        },
+        \"required\": [\"idConversa\"]
+    }")!;
+
+    private static readonly JsonElement AtualizarReservaSchema = JsonSerializer.Deserialize<JsonElement>(@"{
+        \"type\": \"object\",
+        \"properties\": {
+            \"idConversa\": { \"type\": \"string\", \"format\": \"uuid\" },
+            \"codigoReserva\": { \"type\": \"string\" },
+            \"novaHora\": { \"type\": \"string\", \"pattern\": \"^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$\" },
+            \"novaQtd\": { \"type\": \"integer\", \"minimum\": 1 }
+        },
+        \"required\": [\"idConversa\"]
+    }")!;
+
+    public IReadOnlyList<ToolDefinition> GetDeclaredTools()
+    {
+        return new List<ToolDefinition>
+        {
+            new("consultar_reserva", "Consulta reservas existentes", ConsultarReservaSchema),
+            new("atualizar_reserva", "Atualiza reserva existente", AtualizarReservaSchema)
+        };
+    }
+
+    public async Task<ToolExecutionResult> HandleConfirmarReservaAsync(AssistantDecision decisao, CancellationToken cancellationToken = default)
+    {
+        var mensagemNome = ValidarCampo(decisao.NomeCliente, "o nome do responsável pela reserva");
+        if (mensagemNome is not null)
+        {
+            _logger.LogWarning("WRN-TOOL-CONFIRMAR-NOME-INVALIDO");
+            return ToolExecutionResult.Falha(mensagemNome);
+        }
+
+        var mensagemQtd = ValidarCampo(decisao.QuantidadePessoas?.ToString(), "a quantidade de pessoas");
+        if (mensagemQtd is not null)
+        {
+            _logger.LogWarning("WRN-TOOL-CONFIRMAR-QTD-INVALIDA");
+            return ToolExecutionResult.Falha(mensagemQtd);
+        }
+
+        var mensagemData = ValidarCampo(decisao.Data?.ToString("yyyy-MM-dd"), "a data da reserva");
+        if (mensagemData is not null)
+        {
+            _logger.LogWarning("WRN-TOOL-CONFIRMAR-DATA-INVALIDA");
+            return ToolExecutionResult.Falha(mensagemData);
+        }
+        if (decisao.Hora is null)
+        {
+            if (decisao.ContextoAdicional != null && decisao.ContextoAdicional.TryGetValue("hora", out var horaObj))
+            {
+                var horaString = horaObj?.ToString();
+                if (!TryParseHora(horaString, out var horaValida))
+                {
+                    return ToolExecutionResult.Falha("Qual horário você deseja? Pode informar no formato HH:mm, por exemplo 19:00.");
+                }
+
+                decisao.Hora = horaValida;
+            }
+            else
+            {
+                return ToolExecutionResult.Falha("Qual horário você deseja? Pode informar no formato HH:mm, por exemplo 19:00.");
+            }
+        }
+
+        if (decisao.IdConversa.HasValue)
+        {
+            var snapshot = new TentativaReservaSnapshotDto
+            {
+                NomeCliente = decisao.NomeCliente,
+                QuantidadePessoas = decisao.QuantidadePessoas,
+                Data = decisao.Data,
+                Hora = decisao.Hora
+            };
+            await _contextService.SalvarAsync(decisao.IdConversa.Value, TentativaReservaContextKey, snapshot, TimeSpan.FromHours(2), cancellationToken);
+        }
+
+        if (decisao.IdCliente.HasValue && decisao.IdEstabelecimento.HasValue && decisao.Data.HasValue)
+        {
+            var existeConflito = await _reservaService.ExisteConflitoMesmoDiaAsync(decisao.IdCliente.Value, decisao.IdEstabelecimento.Value, decisao.Data.Value, cancellationToken);
+            if (existeConflito)
+            {
+                _logger.LogInformation("INF-TOOL-CONFIRMAR-RESERVA-CONFLITO {@Cliente} {@Dia}", decisao.IdCliente, decisao.Data);
+                Reserva? reservaConflitante = null;
+                var reservas = await _reservaService.ObterReservasAtivasDoClienteAsync(decisao.IdCliente.Value, decisao.IdEstabelecimento.Value, decisao.Data.Value, cancellationToken);
+                reservaConflitante = _reservaService.SelecionarReservaMesmoDia(reservas, decisao.Data.Value);
+                if (decisao.IdConversa.HasValue)
+                {
+                    await _contextService.SalvarAsync(decisao.IdConversa.Value, DecisaoConflitoContextKey, new
+                    {
+                        ReservaId = reservaConflitante?.Id,
+                        Codigo = reservaConflitante?.CodigoFormatado
+                    }, TimeSpan.FromHours(2), cancellationToken);
+                }
+
+                var resumo = reservaConflitante != null ? _reservaService.MontarResumoReserva(reservaConflitante) : string.Empty;
+                var mensagem = $"Você já possui uma reserva confirmada para este dia:\n{resumo}\n\nO que você prefere?\n1) Atualizar esta reserva\n2) Cancelar e criar nova\n3) Manter como está";
+                return ToolExecutionResult.Falha(mensagem);
+            }
+        }
+
+        _logger.LogInformation("INF-TOOL-CONFIRMAR-RESERVA-SUCESSO {@Cliente}", decisao.IdCliente);
+        return ToolExecutionResult.Sucesso("Reserva confirmada com sucesso.");
+    }
+
+    public async Task<ToolExecutionResult> HandleConsultarReservaAsync(AssistantDecision decisao, CancellationToken cancellationToken = default)
+    {
+        if (decisao.IdConversa is null)
+        {
+            return ToolExecutionResult.Falha("Não consegui localizar sua conversa. Pode tentar novamente?");
+        }
+
+        if (!string.IsNullOrWhiteSpace(decisao.CodigoReserva))
+        {
+            var reserva = await _reservaService.ObterReservaPorCodigoAsync(decisao.CodigoReserva, cancellationToken);
+            if (reserva is null)
+            {
+                return ToolExecutionResult.Falha("Não encontrei nenhuma reserva com esse código. Pode conferir?");
+            }
+
+            var resumo = _reservaService.MontarResumoReserva(reserva);
+            return ToolExecutionResult.Sucesso($"Aqui estão os detalhes da sua reserva {reserva.CodigoFormatado}:\n{resumo}");
+        }
+
+        if (decisao.IdCliente is null || decisao.IdEstabelecimento is null)
+        {
+            return ToolExecutionResult.Falha("Para consultar sem código preciso confirmar quem é você. Pode me informar seu nome ou documento cadastrado?");
+        }
+
+        var reservas = await _reservaService.ObterReservasAtivasDoClienteAsync(decisao.IdCliente.Value, decisao.IdEstabelecimento.Value, DateTime.UtcNow, cancellationToken);
+        if (reservas.Count == 0)
+        {
+            return ToolExecutionResult.Sucesso("Não encontrei reservas futuras ativas para você.");
+        }
+
+        var linhas = reservas.Select(r => $"• {r.CodigoFormatado} — {r.Data:dd/MM/yyyy} às {r.Hora:hh\\:mm} para {r.QuantidadePessoas} pessoas").ToArray();
+        var mensagem = "Estas são as suas próximas reservas:\n" + string.Join('\n', linhas) + "\nSe quiser detalhes de alguma delas, é só me informar o código.";
+        return ToolExecutionResult.Sucesso(mensagem);
+    }
+
+    public async Task<ToolExecutionResult> HandleAtualizarReservaAsync(AssistantDecision decisao, CancellationToken cancellationToken = default)
+    {
+        if (decisao.IdConversa is null)
+        {
+            return ToolExecutionResult.Falha("Não consegui identificar a conversa para atualizar a reserva.");
+        }
+
+        var contexto = await _contextService.LerAsync<JsonElement>(decisao.IdConversa.Value, DecisaoConflitoContextKey, cancellationToken);
+        Guid? reservaId = null;
+        string? codigoReserva = decisao.CodigoReserva;
+        if (contexto.ValueKind != JsonValueKind.Undefined && contexto.TryGetProperty("ReservaId", out var reservaIdProp) && reservaIdProp.ValueKind == JsonValueKind.String && Guid.TryParse(reservaIdProp.GetString(), out var parsed))
+        {
+            reservaId = parsed;
+        }
+        else if (contexto.ValueKind != JsonValueKind.Undefined && contexto.TryGetProperty("Codigo", out var codigoProp))
+        {
+            codigoReserva = codigoProp.GetString();
+        }
+
+        if (!string.IsNullOrWhiteSpace(codigoReserva) && reservaId is null)
+        {
+            var reserva = await _reservaService.ObterReservaPorCodigoAsync(codigoReserva!, cancellationToken);
+            reservaId = reserva?.Id;
+            if (reserva is not null)
+            {
+                decisao.IdEstabelecimento ??= reserva.IdEstabelecimento;
+                decisao.IdCliente ??= reserva.IdCliente;
+                decisao.Data ??= reserva.Data;
+            }
+        }
+
+        if (reservaId is null)
+        {
+            return ToolExecutionResult.Falha("Preciso saber qual reserva deseja atualizar. Pode me informar o código?");
+        }
+
+        if (decisao.IdEstabelecimento is null || decisao.Data is null)
+        {
+            return ToolExecutionResult.Falha("Ainda preciso confirmar para qual data e estabelecimento é a reserva antes de atualizar.");
+        }
+
+        if (decisao.QuantidadePessoas is null)
+        {
+            return ToolExecutionResult.Falha("Quantas pessoas irão após a atualização?");
+        }
+
+        if (!decisao.Hora.HasValue)
+        {
+            return ToolExecutionResult.Falha("Qual será o novo horário? Informe no formato HH:mm, por exemplo 20:30.");
+        }
+
+        var sucesso = await _reservaService.AtualizarReservaComCapacidadeAsync(reservaId.Value, decisao.IdEstabelecimento.Value, decisao.Data.Value, decisao.Hora.Value, decisao.QuantidadePessoas.Value, cancellationToken);
+        if (!sucesso)
+        {
+            return ToolExecutionResult.Falha("Não tenho disponibilidade para esse horário ou quantidade. Pode sugerir outro?");
+        }
+
+        await _contextService.RemoverAsync(decisao.IdConversa.Value, DecisaoConflitoContextKey, cancellationToken);
+        await _contextService.RemoverAsync(decisao.IdConversa.Value, TentativaReservaContextKey, cancellationToken);
+
+        var horaFormatada = decisao.Hora.Value.ToString("hh\\:mm");
+        var dataFormatada = decisao.Data?.ToString("dd/MM/yyyy") ?? "data combinada";
+        var mensagem = $"Tudo certo! Atualizei sua reserva para {dataFormatada} às {horaFormatada} para {decisao.QuantidadePessoas} pessoas.";
+        return ToolExecutionResult.Sucesso(mensagem);
+    }
+
+    private static string? ValidarCampo(string? valor, string nomeCampo)
+    {
+        if (string.IsNullOrWhiteSpace(valor))
+        {
+            return $"Não tenho {nomeCampo}. Pode me informar?";
+        }
+
+        var normalizado = valor.Trim().ToLowerInvariant();
+        if (ValoresInvalidos.Any(v => string.Equals(normalizado, v, StringComparison.OrdinalIgnoreCase)))
+        {
+            return $"Recebi {nomeCampo} em branco ou como 'a definir'. Pode confirmar?";
+        }
+        return null;
+    }
+
+    private static bool TryParseHora(string? entrada, out TimeSpan hora)
+    {
+        hora = default;
+        if (string.IsNullOrWhiteSpace(entrada))
+        {
+            return false;
+        }
+
+        entrada = entrada.Trim();
+        if (ValoresInvalidos.Any(v => entrada.Equals(v, StringComparison.OrdinalIgnoreCase)))
+        {
+            return false;
+        }
+
+        return TimeSpan.TryParseExact(entrada, "hh\\:mm", CultureInfo.InvariantCulture, out hora);
+    }
+}
+
+public record ToolDefinition(string Name, string Description, JsonElement Schema);
+
+public record ToolExecutionResult(bool Success, string Message)
+{
+    public static ToolExecutionResult Sucesso(string message) => new(true, message);
+    public static ToolExecutionResult Falha(string message) => new(false, message);
+}


### PR DESCRIPTION
## Resumo
- cria estrutura de automação com serviços e repositórios resilientes para reservas
- adiciona memória de conversa, idempotência e novas ferramentas de consulta/atualização
- configura HttpClient com timeout/retry e middleware de idempotência no webhook

## Testes
- não aplicável (alterações estruturais sem testes automatizados disponíveis)


------
https://chatgpt.com/codex/tasks/task_e_68e1a1993d60832898843e7987c5019d